### PR TITLE
Split out http and mongo functionality into distinct components

### DIFF
--- a/chapter6/api/httpServer.go
+++ b/chapter6/api/httpServer.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"net/http"
+
+	"golang.org/x/net/context"
+)
+
+// httpServer is an implementation for storing polls
+// via http with an agnostic storage backend
+type httpServer struct {
+	storage PollStorage
+}
+
+func NewHttpServer(storage PollStorage) *httpServer {
+	return &httpServer{storage: storage}
+}
+
+func (s *httpServer) Routes(w http.ResponseWriter, r *http.Request) {
+	withCORS(withAPIKey(s.handlePolls))
+}
+
+func (s *httpServer) handlePolls(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case "GET":
+		s.handlePollsGet(w, r)
+		return
+	case "POST":
+		s.handlePollsPost(w, r)
+		return
+	case "DELETE":
+		s.handlePollsDelete(w, r)
+		return
+	case "OPTIONS":
+		w.Header().Set("Access-Control-Allow-Methods", "DELETE")
+		respond(w, r, http.StatusOK, nil)
+		return
+	}
+	// not found
+	respondHTTPErr(w, r, http.StatusNotFound)
+}
+
+func (s *httpServer) handlePollsGet(w http.ResponseWriter, r *http.Request) {
+	p := NewPath(r.URL.Path)
+	result, err := s.storage.Get(p)
+	if err != nil {
+		respondErr(w, r, http.StatusInternalServerError, err)
+		return
+	}
+	respond(w, r, http.StatusOK, &result)
+}
+
+func (s *httpServer) handlePollsPost(w http.ResponseWriter, r *http.Request) {
+	var p Poll
+	if err := decodeBody(r, &p); err != nil {
+		respondErr(w, r, http.StatusBadRequest, "failed to read poll from request", err)
+		return
+	}
+	apikey, ok := APIKey(r.Context())
+	if ok {
+		p.APIKey = apikey
+	}
+	id, err := s.storage.Create(&p)
+	if err != nil {
+		respondErr(w, r, http.StatusInternalServerError, "failed to insert poll", err)
+		return
+	}
+	w.Header().Set("Location", "polls/"+id)
+	respond(w, r, http.StatusCreated, nil)
+}
+
+func (s *httpServer) handlePollsDelete(w http.ResponseWriter, r *http.Request) {
+	p := NewPath(r.URL.Path)
+
+	err := s.storage.Delete(p)
+
+	if err == ErrCannotDeleteAll {
+		respondErr(w, r, http.StatusMethodNotAllowed, "Cannot delete all polls.")
+		return
+	}
+
+	if err != nil {
+		respondErr(w, r, http.StatusInternalServerError, "failed to delete poll", err)
+		return
+	}
+	respond(w, r, http.StatusOK, nil) // ok
+}
+
+func withCORS(fn http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Expose-Headers", "Location")
+		fn(w, r)
+	}
+}
+
+type contextKey struct {
+	name string
+}
+
+var contextKeyAPIKey = &contextKey{"api-key"}
+
+func APIKey(ctx context.Context) (string, bool) {
+	key := ctx.Value(contextKeyAPIKey)
+	if key == nil {
+		return "", false
+	}
+	keystr, ok := key.(string)
+	return keystr, ok
+}
+
+func withAPIKey(fn http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		key := r.URL.Query().Get("key")
+		if !isValidAPIKey(key) {
+			respondErr(w, r, http.StatusUnauthorized, "invalid API key")
+			return
+		}
+		ctx := context.WithValue(r.Context(), contextKeyAPIKey, key)
+		fn(w, r.WithContext(ctx))
+	}
+}
+
+func isValidAPIKey(key string) bool {
+	return key == "abc123"
+}

--- a/chapter6/api/mongoStorage.go
+++ b/chapter6/api/mongoStorage.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+)
+
+// mongoStorage is a private structure for
+// storing polls with a MongoDB database
+type mongoStorage struct {
+	db *mgo.Session
+}
+
+// NewMongoStorage returns a Storage interface
+// backed by the private mongoStorage struct
+func NewMongoStorage(db *mgo.Session) PollStorage {
+	return &mongoStorage{db: db}
+}
+
+func (s *mongoStorage) Get(p *Path) ([]*Poll, error) {
+	session := s.db.Copy()
+	defer session.Close()
+	c := session.DB("ballots").C("polls")
+	var q *mgo.Query
+	if p.HasID() {
+		// get specific poll
+		q = c.FindId(bson.ObjectIdHex(p.ID))
+	} else {
+		// get all polls
+		q = c.Find(nil)
+	}
+	var result []*Poll
+	if err := q.All(&result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (s *mongoStorage) Create(p *Poll) (string, error) {
+	session := s.db.Copy()
+	defer session.Close()
+	c := session.DB("ballots").C("polls")
+	p.ID = bson.NewObjectId()
+	if err := c.Insert(p); err != nil {
+		return "", err
+	}
+	return p.ID.Hex(), nil
+}
+
+func (s *mongoStorage) Delete(p *Path) error {
+	session := s.db.Copy()
+	defer session.Close()
+	c := session.DB("ballots").C("polls")
+
+	if !p.HasID() {
+		return ErrCannotDeleteAll
+	}
+
+	if err := c.RemoveId(bson.ObjectIdHex(p.ID)); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/chapter6/api/polls.go
+++ b/chapter6/api/polls.go
@@ -1,13 +1,19 @@
 package main
 
 import (
-	"net/http"
+	"errors"
 
-	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 )
 
-type poll struct {
+var (
+	// ErrCannotDeleteAll is used to identify a client-facing
+	// error when deleting a poll from storage
+	ErrCannotDeleteAll = errors.New("cannot delete all polls")
+)
+
+// Poll represents a poll. ID should not be a BSON object
+type Poll struct {
 	ID      bson.ObjectId  `bson:"_id" json:"id"`
 	Title   string         `json:"title" bson:"title"`
 	Options []string       `json:"options"`
@@ -15,81 +21,10 @@ type poll struct {
 	APIKey  string         `json:"apikey"`
 }
 
-func (s *Server) handlePolls(w http.ResponseWriter, r *http.Request) {
-	switch r.Method {
-	case "GET":
-		s.handlePollsGet(w, r)
-		return
-	case "POST":
-		s.handlePollsPost(w, r)
-		return
-	case "DELETE":
-		s.handlePollsDelete(w, r)
-		return
-	case "OPTIONS":
-		w.Header().Set("Access-Control-Allow-Methods", "DELETE")
-		respond(w, r, http.StatusOK, nil)
-		return
-	}
-	// not found
-	respondHTTPErr(w, r, http.StatusNotFound)
-}
-
-func (s *Server) handlePollsGet(w http.ResponseWriter, r *http.Request) {
-	session := s.db.Copy()
-	defer session.Close()
-	c := session.DB("ballots").C("polls")
-	var q *mgo.Query
-	p := NewPath(r.URL.Path)
-	if p.HasID() {
-		// get specific poll
-		q = c.FindId(bson.ObjectIdHex(p.ID))
-	} else {
-		// get all polls
-		q = c.Find(nil)
-	}
-	var result []*poll
-	if err := q.All(&result); err != nil {
-		respondErr(w, r, http.StatusInternalServerError, err)
-		return
-	}
-	respond(w, r, http.StatusOK, &result)
-}
-
-func (s *Server) handlePollsPost(w http.ResponseWriter, r *http.Request) {
-	session := s.db.Copy()
-	defer session.Close()
-	c := session.DB("ballots").C("polls")
-	var p poll
-	if err := decodeBody(r, &p); err != nil {
-		respondErr(w, r, http.StatusBadRequest, "failed to read poll from request", err)
-		return
-	}
-	apikey, ok := APIKey(r.Context())
-	if ok {
-		p.APIKey = apikey
-	}
-	p.ID = bson.NewObjectId()
-	if err := c.Insert(p); err != nil {
-		respondErr(w, r, http.StatusInternalServerError, "failed to insert poll", err)
-		return
-	}
-	w.Header().Set("Location", "polls/"+p.ID.Hex())
-	respond(w, r, http.StatusCreated, nil)
-}
-
-func (s *Server) handlePollsDelete(w http.ResponseWriter, r *http.Request) {
-	session := s.db.Copy()
-	defer session.Close()
-	c := session.DB("ballots").C("polls")
-	p := NewPath(r.URL.Path)
-	if !p.HasID() {
-		respondErr(w, r, http.StatusMethodNotAllowed, "Cannot delete all polls.")
-		return
-	}
-	if err := c.RemoveId(bson.ObjectIdHex(p.ID)); err != nil {
-		respondErr(w, r, http.StatusInternalServerError, "failed to delete poll", err)
-		return
-	}
-	respond(w, r, http.StatusOK, nil) // ok
+// PollStorage represents an abstraction to a storage
+// backend for Polls
+type PollStorage interface {
+	Get(p *Path) ([]*Poll, error)
+	Create(p *Poll) (string, error)
+	Delete(p *Path) error
 }


### PR DESCRIPTION
In my comments for chapter six I noted it would be beneficial to
split the mongo-specific functionality with the http api for better
code composition. This could open the door for different backends 
(say, C*) and different transports (say, gRPC). Feel free to disregard
and close, but I wanted to put an implementation out there. Happy
to iterate at your request, and accept any contributor agreements
required.